### PR TITLE
adds CODE_OF_CONDUCT.md file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+While Translational Analytics and Statistics predominantly have closed source code licensed for profit, we operate under the same covenant open source projects.
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing other's private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within and in public spaces when an individual represents the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at opensource@microsoft.com. The project team will look over and investigate all complaints and respond in a way that's appropriate to the circumstances. The project team has to maintain confidentiality concerning the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other project leadership members.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Microsoft FAST][stack] and [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version].
+
+[stack]: https://raw.githubusercontent.com/microsoft/fast/master/CODE_OF_CONDUCT.md
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
This will add a baseline code of conduct file to all repositories if one does not already exist.